### PR TITLE
Add projects page, ai-toolkit entry, and new blog post

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,3 +1,12 @@
+- name: ai-toolkit
+  description: A collection of Claude Code skills and agents for AI-assisted development. Includes a pedantic-reader skill that reviews written content for accuracy and credibility by verifying claims against live web sources.
+  github: https://github.com/amod0017/ai-toolkit
+  tech:
+    - Claude Code
+    - Markdown
+    - Prompt Engineering
+  status: active
+
 - name: contribution-logger
   description: A local Streamlit dashboard that turns sprint task CSVs into interactive charts for engineering performance reviews. Tracks KPIs like AI adoption rate, proactive initiative %, and services touched.
   github: https://github.com/amod0017/contribution-logger

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -11,7 +11,7 @@ layout: default
 
   {% assign posts = paginator.posts | default: site.posts %}
   {% assign first_post = posts | first %}
-  {% assign other_posts = posts | slice: 1, 3 %}
+  {% assign other_posts = posts | slice: 1, 4 %}
 
   {% if first_post %}
   <a class="hero-post" href="{{ site.baseurl }}{{ first_post.url }}">

--- a/_posts/2026-05-14-metas-ai-leaderboard-is-just-story-points.md
+++ b/_posts/2026-05-14-metas-ai-leaderboard-is-just-story-points.md
@@ -1,0 +1,59 @@
+---
+layout: post
+title: "Meta's AI Leaderboard Is Just Story Points With a Bigger Budget"
+image: assets/images/post-token-legend.svg
+author: "Amod"
+categories: [ tech, engineering ]
+tags: [ ai, agile, productivity, engineering-culture ]
+comments: true
+---
+
+A Meta engineer built an internal leaderboard called "Claudeonomics." It ranked 85,000+ employees by how many AI tokens they consumed. Top performers earned titles: "Session Immortal" at the lower tier, "Token Legend" at the top.
+
+In 30 days, Meta employees burned through 60 trillion tokens. Estimated cost at standard API rates: $900 million.
+
+Some of those tokens went toward real work. A lot of them went toward running agents that produced nothing, generating throwaway code, and building projects nobody would ever ship. The point was not the output. The point was the leaderboard position.
+
+Meta shut it down after internal data was shared externally.
+
+---
+
+I've been in enough sprint planning meetings to recognize this pattern.
+
+The ritual goes like this: someone puts a ticket on the screen. Everyone stares at it. Someone says "three." Someone else says "five." Then fifteen minutes disappear arguing about the difference, and the ticket gets pointed at a four, a number that satisfies nobody and predicts nothing.
+
+By quarter's end, the team's velocity looks great. Did we ship what mattered? That's a different question.
+
+Story points were invented to measure complexity, not time. Somewhere along the way they became a delivery forecast, a team performance metric, a number managers put in slides. Velocity stopped measuring how well the team worked and started measuring how well the team pointed.
+
+The two things are not the same.
+
+---
+
+There's a law for this. Goodhart's Law: when a measure becomes a target, it ceases to be a good measure.
+
+It explains the Claudeonomics leaderboard. It explains sprint velocity. It explains lines of code as a productivity metric. The specific measure changes with the era. The failure mode is identical.
+
+Organizations need to show progress upward. Managers need evidence for the quarterly review. AI adoption is the current mandate, and token counts are the only number that's easy to collect. So token counts become the target. Engineers aren't gaming the system out of laziness. They're doing exactly what the incentive structure asks them to do.
+
+---
+
+Recently I got pulled into architecture discussions on a codebase I had no prior context on. I used AI to understand the system, verify my reading of the code, and put together a proposal. No code came out of it. My idea may not even be the one we go with. But I could participate meaningfully in a decision that would have taken me weeks to get up to speed on otherwise. That has value. It just doesn't fit in a token count column.
+
+The other side of this is also true. I am not a UI developer. I recently needed to make UI changes and they came out exactly as expected, concrete outcome and all. But I was deliberate about it. I planned the work carefully specifically to keep token consumption low. The goal was the UI change, not the tokens. The tokens were just a cost to manage.
+
+Tokens are a cost, not a score.
+
+---
+
+Here's the thing: measuring AI adoption with token counts is not wrong. It's a reasonable starting signal. If usage is near zero, that tells you something.
+
+The problem is when the measurement becomes the competition. HubSpot's CEO put it simply: outcome maxxing beats token maxxing. The leaderboard was not measuring AI adoption. It was measuring the human capacity to optimize for whatever number is in front of us.
+
+We have always done this. We will do it again with whatever metric comes next.
+
+Name it when you see it.
+
+---
+
+*Sources: [The Pragmatic Engineer](https://blog.pragmaticengineer.com/the-pulse-tokenmaxxing-as-a-weird-new-trend/), [Trending Topics EU](https://www.trendingtopics.eu/tokenmaxxing-is-ai-token-consumption-a-productivity-metric-or-vanity-trap/)*

--- a/assets/images/post-token-legend.svg
+++ b/assets/images/post-token-legend.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <defs>
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Caveat:wght@400;700&amp;display=swap');
+      text { font-family: 'Caveat', 'Comic Sans MS', cursive; }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="#FAFAF8"/>
+
+  <!-- Subtle paper texture lines -->
+  <line x1="0" y1="210" x2="1200" y2="210" stroke="#e8e8e4" stroke-width="1"/>
+  <line x1="0" y1="420" x2="1200" y2="420" stroke="#e8e8e4" stroke-width="1"/>
+
+  <!-- ═══ LEFT BOX: STORY POINTS ═══ -->
+  <!-- Rough rectangle (hand-drawn feel) -->
+  <path d="M 72,82 C 130,78 230,80 348,83 C 351,140 352,220 349,318 C 280,322 170,320 71,317 C 68,250 69,160 72,82 Z"
+        fill="#ffffff" stroke="#1e1e2e" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Title underline -->
+  <line x1="80" y1="118" x2="342" y2="118" stroke="#1e1e2e" stroke-width="1.5" stroke-linecap="round"
+        stroke-dasharray="0" opacity="0.4"/>
+
+  <text x="210" y="112" font-size="22" font-weight="700" fill="#1e1e2e" text-anchor="middle">Sprint Planning 🃏</text>
+
+  <!-- Poker card sketch -->
+  <path d="M 138,145 C 145,143 195,144 222,146 C 224,185 224,235 222,268 C 200,270 155,270 137,268 C 135,235 135,180 138,145 Z"
+        fill="#f0f0ed" stroke="#1e1e2e" stroke-width="2" stroke-linecap="round"/>
+  <text x="180" y="218" font-size="58" font-weight="700" fill="#1e1e2e" text-anchor="middle">5</text>
+  <text x="180" y="258" font-size="13" fill="#888" text-anchor="middle">story pts</text>
+
+  <!-- Scribbled annotation -->
+  <text x="248" y="175" font-size="17" fill="#e05c2a" transform="rotate(-4, 248, 175)">wait... is it</text>
+  <text x="245" y="198" font-size="17" fill="#e05c2a" transform="rotate(-4, 245, 198)">a 3 or an 8?</text>
+
+  <!-- Arrow pointing from 5 -->
+  <path d="M 228,207 C 248,205 262,202 275,200" stroke="#e05c2a" stroke-width="1.8" fill="none" stroke-linecap="round" stroke-dasharray="4,3"/>
+  <path d="M 272,196 L 278,200 L 271,204" fill="none" stroke="#e05c2a" stroke-width="1.8" stroke-linecap="round"/>
+
+  <!-- Velocity note -->
+  <text x="100" y="300" font-size="16" fill="#888">velocity this sprint: 47 📈</text>
+  <text x="105" y="310" font-size="13" fill="#aaa">(did we ship what mattered? 🤷)</text>
+
+
+  <!-- ═══ RIGHT BOX: CLAUDEONOMICS ═══ -->
+  <path d="M 558,62 C 650,58 820,61 1138,64 C 1141,160 1142,330 1138,448 C 900,452 700,450 558,448 C 555,340 556,170 558,62 Z"
+        fill="#ffffff" stroke="#1e1e2e" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <text x="848" y="106" font-size="26" font-weight="700" fill="#1e1e2e" text-anchor="middle">🏆 CLAUDEONOMICS</text>
+  <line x1="568" y1="118" x2="1128" y2="118" stroke="#1e1e2e" stroke-width="1.5" stroke-linecap="round" opacity="0.4"/>
+  <text x="848" y="142" font-size="15" fill="#888" text-anchor="middle">internal leaderboard · 85,000 employees</text>
+
+  <!-- Column headers -->
+  <text x="590" y="175" font-size="16" fill="#aaa">  RANK    NAME                   TOKENS        SHIPPED</text>
+  <line x1="578" y1="182" x2="1128" y2="182" stroke="#ccc" stroke-width="1" stroke-linecap="round"/>
+
+  <!-- Row 1 - highlighted -->
+  <path d="M 576,186 C 700,184 950,185 1126,187 C 1127,205 1127,215 1126,220 C 950,222 700,221 576,220 C 575,212 575,196 576,186 Z"
+        fill="#fff9e6" stroke="none"/>
+  <text x="590" y="208" font-size="18" fill="#c8860a">  🥇  TOKEN_LEGEND_01         60,000,000,000T    ???</text>
+
+  <text x="590" y="238" font-size="17" fill="#555">  🥈  SESSION_IMMORTAL_42     44,200,000,000T    ???</text>
+  <text x="590" y="264" font-size="17" fill="#555">  🥉  VELOCITY_HERO_99        31,500,000,000T    ???</text>
+
+  <line x1="578" y1="278" x2="1128" y2="278" stroke="#ccc" stroke-width="1" stroke-linecap="round" stroke-dasharray="5,4"/>
+
+  <!-- The quiet row -->
+  <text x="590" y="305" font-size="17" fill="#aaa">   4    just_doing_real_work        142,000T    ✓ 12 PRs</text>
+
+  <!-- Annotation arrow pointing to row 4 -->
+  <path d="M 1050,330 C 1060,318 1065,312 1060,306" stroke="#2a7a2a" stroke-width="1.8" fill="none" stroke-linecap="round"/>
+  <path d="M 1057,303 L 1062,308 L 1056,310" fill="none" stroke="#2a7a2a" stroke-width="1.8" stroke-linecap="round"/>
+  <text x="1055" y="348" font-size="16" fill="#2a7a2a" text-anchor="middle" transform="rotate(3, 1055, 348)">this one</text>
+  <text x="1050" y="366" font-size="16" fill="#2a7a2a" text-anchor="middle" transform="rotate(3, 1050, 366)">actually shipped</text>
+
+  <!-- Abolished note -->
+  <path d="M 590,400 C 700,397 900,398 1120,400 C 1122,428 1121,440 1120,442 C 900,444 700,443 590,442 C 588,432 588,412 590,400 Z"
+        fill="#fff0f0" stroke="#e05c2a" stroke-width="1.5" stroke-linecap="round" stroke-dasharray="5,3"/>
+  <text x="855" y="426" font-size="16" fill="#e05c2a" text-anchor="middle">⚠️  leaderboard abolished after press coverage. reason listed: "misuse"</text>
+
+
+  <!-- ═══ CENTER CONNECTOR ═══ -->
+  <!-- Curly brace / equals sign area -->
+  <path d="M 358,198 C 390,185 430,182 468,185 C 500,188 530,192 558,197"
+        stroke="#1e1e2e" stroke-width="2" fill="none" stroke-linecap="round" stroke-dasharray="6,4"/>
+  <text x="460" y="175" font-size="19" font-weight="700" fill="#1e1e2e" text-anchor="middle" transform="rotate(-8, 460, 175)">same</text>
+  <text x="458" y="197" font-size="19" font-weight="700" fill="#1e1e2e" text-anchor="middle" transform="rotate(-8, 458, 197)">energy</text>
+
+
+  <!-- ═══ BOTTOM LABEL ═══ -->
+  <text x="600" y="555" font-size="21" font-weight="700" fill="#1e1e2e" text-anchor="middle">
+    Goodhart's Law: when a measure becomes a target, it ceases to be a good measure.
+  </text>
+  <text x="600" y="585" font-size="16" fill="#aaa" text-anchor="middle">— story points (2001)  ·  token counts (2025)  ·  whatever's next</text>
+
+</svg>


### PR DESCRIPTION
## Summary

- Projects page: replaced "Coming soon" placeholder with a data-driven card grid powered by `_data/projects.yml`. Adding a new project is a single YAML entry. Initial entries: contribution-logger and ai-toolkit.
- New post: "Meta's AI Leaderboard Is Just Story Points With a Bigger Budget" — a rant about Goodhart's Law, tokenmaxxing, and why we keep gaming our own metrics. Includes Excalidraw-style sketch image.
- Homepage: increased grid from 3 to 4 posts (hero + 4 cards = 5 total).

## Test plan

- [ ] `/projects/` renders both project cards correctly in light and dark mode
- [ ] New post appears on homepage and renders fully with image
- [ ] Homepage shows hero + 4 grid cards
- [ ] Sources in post link to correct URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)