### PR TITLE
Fix category 404s: GitHub Actions workflow for full Jekyll build

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,51 @@
+name: Deploy Jekyll site to GitHub Pages
+
+on:
+  push:
+    branches: ["master"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -2,15 +2,20 @@
 layout: default
 ---
 
-{% assign recent_posts = page.posts | slice: 0, 3 %}
-{% assign older_posts = page.posts | slice: 3, 100 %}
+{% if page.posts %}
+  {% assign all_posts = page.posts %}
+{% else %}
+  {% assign all_posts = site.posts | where_exp: "post", "post.categories contains page.category" %}
+{% endif %}
+{% assign recent_posts = all_posts | slice: 0, 3 %}
+{% assign older_posts = all_posts | slice: 3, 100 %}
 
 <div class="page page--wide">
 
   <div class="archive-header">
     <div class="post-cat">{{ page.title }}</div>
     <h1>{{ page.title }}</h1>
-    <p class="archive-count">{{ page.posts.size }} post{% if page.posts.size != 1 %}s{% endif %}</p>
+    <p class="archive-count">{{ all_posts.size }} post{% if all_posts.size != 1 %}s{% endif %}</p>
   </div>
 
   {% if recent_posts.size > 0 %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,18 +28,18 @@
   <div class="nav-right">
     <ul class="nav-links" id="nav-links">
       <li class="has-dropdown">
-        <a href="{{ site.baseurl }}/blog" class="dropdown-toggle" id="blog-toggle">Blog</a>
+        <a href="{{ site.baseurl }}/blog/" class="dropdown-toggle" id="blog-toggle">Blog</a>
         <ul class="nav-dropdown" id="blog-dropdown">
           {% assign sorted_cats = site.categories | sort %}
           {% for cat in sorted_cats %}
           <li><a href="{{ '/category/' | append: cat[0] | downcase | replace: ' ', '-' | append: '/' | relative_url }}">{{ cat[0] }}</a></li>
           {% endfor %}
           <li class="nav-dropdown-divider"></li>
-          <li><a href="{{ site.baseurl }}/blog">All Posts</a></li>
+          <li><a href="{{ site.baseurl }}/blog/">All Posts</a></li>
         </ul>
       </li>
-      <li><a href="{{ site.baseurl }}/projects">Projects</a></li>
-      <li><a href="{{ site.baseurl }}/about">About</a></li>
+      <li><a href="{{ site.baseurl }}/projects/">Projects</a></li>
+      <li><a href="{{ site.baseurl }}/about/">About</a></li>
     </ul>
     <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode"></button>
   </div>


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow (`.github/workflows/jekyll.yml`) to build Jekyll with full plugin support, including `jekyll-archives` for category pages
- Fix `_layouts/archive.html` to work both with `jekyll-archives` (`page.posts`) and manual `page.category` filtering as a fallback
- Fix nav links in `_layouts/default.html` to use trailing slashes for consistent routing

## Why
GitHub Pages' built-in Jekyll builder silently ignores unsupported plugins (including `jekyll-archives`), so category pages were never generated — resulting in 404s on `/category/engineering/` etc. GitHub Actions runs the full Jekyll build with all gems, then hands the pre-built site to GitHub Pages to serve.

## Test plan
- [ ] Merge this PR to master
- [ ] In GitHub repo Settings → Pages → Build and deployment → Source, change from **"Deploy from a branch"** to **"GitHub Actions"**
- [ ] Wait for the Actions workflow to complete
- [ ] Verify `https://amod0017.github.io/category/engineering/` (and other categories) return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)